### PR TITLE
Recovery

### DIFF
--- a/storage/innobase/CMakeLists.txt
+++ b/storage/innobase/CMakeLists.txt
@@ -20,6 +20,7 @@ INCLUDE(innodb.cmake)
 SET(INNOBASE_SOURCES
 	pmem/pmem0mmap.cc
 	pmem/pmem0buf.cc
+	pmem/pmem0recv.cc
 	api/api0api.cc
 	api/api0misc.cc
 	btr/btr0btr.cc

--- a/storage/innobase/btr/btr0cur.cc
+++ b/storage/innobase/btr/btr0cur.cc
@@ -4943,6 +4943,10 @@ btr_cur_del_mark_set_clust_rec(
 			ulint cur_rec_size = rec_offs_size(offsets); 
 			pm_mmap_mtrlogbuf_commit(rec, cur_rec_size, nvm_bpage->id.space(), nvm_bpage->id.page_no());
     } else {
+        if ( nvm_bpage->id.space() == 28) {
+          fprintf(stderr, "[JONGQ] WATCH-OUT-2\n");
+          exit(-1);
+        }
         btr_cur_del_mark_set_clust_rec_log(rec, index, trx->id,
 					    roll_ptr, mtr);
     }
@@ -5048,10 +5052,16 @@ btr_cur_del_mark_set_sec_rec(
 	rec_t*		rec;
 	dberr_t		err;
 
+
 	block = btr_cur_get_block(cursor);
 	rec = btr_cur_get_rec(cursor);
 
-	err = lock_sec_rec_modify_check_and_lock(flags,
+  fprintf(stderr,"[JONGQ] btr_cur_del_mark_set_sec_rec! space: %lu\n", block->page.id.space());
+  if (block->page.id.space() == 28) {
+    fprintf(stderr, "[JONGQ] WRONG!!!\n");
+  }
+	
+  err = lock_sec_rec_modify_check_and_lock(flags,
 						 btr_cur_get_block(cursor),
 						 rec, cursor->index, thr, mtr);
 	if (err != DB_SUCCESS) {
@@ -6544,7 +6554,6 @@ btr_cur_unmark_extern_fields(
 
 	for (i = 0; i < n; i++) {
 		if (rec_offs_nth_extern(offsets, i)) {
-
 			btr_cur_set_ownership_of_extern_field(
 				page_zip, rec, index, offsets, i, TRUE, mtr);
 		}
@@ -7534,6 +7543,11 @@ btr_rec_free_externally_stored_fields(
 {
 	ulint	n_fields;
 	ulint	i;
+
+  // dbug
+  if (index->space == 28) {
+    fprintf(stderr, "[JONGQ] btr_rec_Free_externally_stored_fields\n");
+  }
 
 	ut_ad(rec_offs_validate(rec, index, offsets));
 	ut_ad(mtr_is_page_fix(mtr, rec, MTR_MEMO_PAGE_X_FIX, index->table));

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -798,11 +798,10 @@ buf_page_is_corrupted(
 
 		/* Stored log sequence numbers at the start and the end
 		of page do not match */
-
 		return(TRUE);
 	}
 
-#if !defined(UNIV_HOTBACKUP) && !defined(UNIV_INNOCHECKSUM)
+#if !defined(UNIV_HOTBACKUP) && !defined(UNIV_INNOCHECKSUM) &!defined(UNIV_NVDIMM_CACHE)
 	if (check_lsn && recv_lsn_checks_on) {
 		lsn_t		current_lsn;
 		const lsn_t	page_lsn
@@ -973,7 +972,6 @@ buf_page_is_corrupted(
 				page_no, is_log_enabled, log_file, curr_algo,
 #endif /* UNIV_INNOCHECKSUM */
 				true)) {
-
 				return(FALSE);
 			}
 			legacy_checksum_checked = true;
@@ -1084,7 +1082,6 @@ buf_page_is_corrupted(
 					page_id);
 			}
 #endif /* UNIV_INNOCHECKSUM */
-
 			return(FALSE);
 		}
 

--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -1047,7 +1047,15 @@ buf_flush_write_block_low(
 
 	/* Force the log to the disk before writing the modified block */
 	if (!srv_read_only_mode) {
-		log_write_up_to(bpage->newest_modification, true);
+		#if defined(UNIV_NVDIMM_CACHE_NO) && defined(UNIV_NVDIMM_CACHE_OL)
+			if (bpage->id.space() != 28) {
+				log_write_up_to(bpage->newest_modification, true);
+			} else {
+				//fprintf(stderr, "avoid neworder page to flush REDO log file\n");
+			}
+		#else
+			log_write_up_to(bpage->newest_modification, true);
+		#endif
 	}
 
 	switch (buf_page_get_state(bpage)) {

--- a/storage/innobase/buf/buf0rea.cc
+++ b/storage/innobase/buf/buf0rea.cc
@@ -153,6 +153,12 @@ buf_read_page_low(
 		return(0);
 	}
 
+  // debug
+// fprintf(stderr, "[JONGQ] read page %u:%u size=%u unzip=%u, sync=%d\n"
+//                , (unsigned) page_id.space(),
+//                  (unsigned) page_id.page_no(),
+//                  (unsigned) page_size.physical(), (unsigned) unzip, sync);
+
 	DBUG_PRINT("ib_buf", ("read page %u:%u size=%u unzip=%u,%s",
 			      (unsigned) page_id.space(),
 			      (unsigned) page_id.page_no(),
@@ -227,7 +233,7 @@ buf_read_page_low(
 			return(0);
 		}
 	}
-
+  
 	return(1);
 }
 
@@ -873,12 +879,13 @@ buf_read_recv_pages(
 		/* The tablespace is missing: do nothing */
 		return;
 	}
-
+  
 	fil_space_open_if_needed(space);
 
 	const page_size_t	page_size(space->flags);
 
 	for (i = 0; i < n_stored; i++) {
+
 		buf_pool_t*		buf_pool;
 		const page_id_t	cur_page_id(space_id, page_nos[i]);
 
@@ -886,14 +893,12 @@ buf_read_recv_pages(
 
 		buf_pool = buf_pool_get(cur_page_id);
 		while (buf_pool->n_pend_reads >= recv_n_pool_free_frames / 2) {
-
 			os_aio_simulated_wake_handler_threads();
 			os_thread_sleep(10000);
 
 			count++;
 
 			if (!(count % 1000)) {
-
 				ib::error()
 					<< "Waited for " << count / 100
 					<< " seconds for "
@@ -901,7 +906,7 @@ buf_read_recv_pages(
 					<< " pending reads";
 			}
 		}
-
+    
 		if ((i + 1 == n_stored) && sync) {
 			buf_read_page_low(
 				&err, true,

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -5578,8 +5578,8 @@ fil_io(
 	least one file while holding it, if the file is not already open */
 
 	fil_mutex_enter_and_prepare_for_io(page_id.space());
-
-	fil_space_t*	space = fil_space_get_by_id(page_id.space());
+	
+  fil_space_t*	space = fil_space_get_by_id(page_id.space());
 
 	/* If we are deleting a tablespace we don't allow async read operations
 	on that. However, we do allow write operations and sync read operations. */
@@ -5609,14 +5609,12 @@ fil_io(
 	fil_node_t*	node = UT_LIST_GET_FIRST(space->chain);
 
 	for (;;) {
-
 		if (node == NULL) {
-
 			if (req_type.ignore_missing()) {
 				mutex_exit(&fil_system->mutex);
 				return(DB_ERROR);
 			}
-
+			
 			fil_report_invalid_page_access(
 				page_id.page_no(), page_id.space(),
 				space->name, byte_offset, len,
@@ -5632,7 +5630,6 @@ fil_io(
 		} else if (node->size > cur_page_no) {
 			/* Found! */
 			break;
-
 		} else {
 			if (space->id != srv_sys_space.space_id()
 			    && UT_LIST_GET_LEN(space->chain) == 1
@@ -5649,7 +5646,6 @@ fil_io(
 			}
 
 			cur_page_no -= node->size;
-
 			node = UT_LIST_GET_NEXT(chain, node);
 		}
 	}
@@ -5672,7 +5668,6 @@ fil_io(
 						     cur_page_no)
 					<< ", I/O length: " << len << " bytes";
 			}
-
 			return(DB_TABLESPACE_DELETED);
 		}
 
@@ -5774,7 +5769,7 @@ fil_io(
 #ifdef UNIV_HOTBACKUP
 	/* In mysqlbackup do normal i/o, not aio */
 	if (req_type.is_read()) {
-
+    
 		err = os_file_read(req_type, node->handle, buf, offset, len);
 
 	} else {
@@ -5793,7 +5788,6 @@ fil_io(
 		fsp_is_system_temporary(page_id.space())
 		? false : srv_read_only_mode,
 		node, message);
-
 #endif /* UNIV_HOTBACKUP */
 
 	if (err == DB_IO_NO_PUNCH_HOLE) {
@@ -5827,7 +5821,6 @@ fil_io(
 
 		ut_ad(fil_validate_skip());
 	}
-
 	return(err);
 }
 

--- a/storage/innobase/include/mtr0mtr.h
+++ b/storage/innobase/include/mtr0mtr.h
@@ -49,6 +49,7 @@ Created 11/26/1995 Heikki Tuuri
 #ifdef UNIV_NVDIMM_CACHE
 /** Commit a mini-transaction for nvdimm resident pages */
 #define mtr_commit_nvm(m) (m)->commit_nvm()
+#define mtr_commit_no_nvm(m) (m)->commit_no_nvm()
 #endif /* UNIV_NVDIMM_CACHE */
 
 /** Set and return a savepoint in mtr.
@@ -264,6 +265,7 @@ struct mtr_t {
 #ifdef UNIV_NVDIMM_CACHE
     /** Commit the mini-transaction for nvm resident page. */
     void commit_nvm();
+		void commit_no_nvm();
 #endif /* UNIV_NVDIMM_CACHE */
 
 	/** Commit a mini-transaction that did not modify any pages,

--- a/storage/innobase/include/pmem_mmap_obj.h
+++ b/storage/innobase/include/pmem_mmap_obj.h
@@ -169,7 +169,6 @@ struct __pmem_mmap_mtrlog_hdr {
 };
 
 // logging? 
-
 int pm_mmap_mtrlogbuf_init(const size_t size);
 void pm_mmap_mtrlogbuf_mem_free();
 void pm_mmap_read_logfile_header(PMEM_MMAP_MTRLOGFILE_HDR* mtrlog_fil_hdr);
@@ -178,7 +177,6 @@ void pm_mmap_write_logfile_header_lsn(uint64_t lsn);
 void pm_mmap_write_logfile_header_ckpt_info(uint64_t offset, uint64_t lsn);
 uint64_t pm_mmap_log_checkpoint(uint64_t cur_offset);
 void pm_mmap_log_commit(unsigned long cur_space, unsigned long cur_page, uint64_t cur_offset);
-
 
 ssize_t pm_mmap_mtrlogbuf_write(const uint8_t* buf, 
                                 unsigned long int n, unsigned long int lsn);
@@ -193,4 +191,32 @@ void pm_mmap_buf_init(const uint64_t size);
 void pm_mmap_buf_free(void);
 void pm_mmap_buf_write(unsigned long len, void* buf);
 //unsigned char* pm_mmap_buf_chunk_alloc(unsigned long mem_size, ut_new_pfx_t* pfx);
+
+
+// recovery
+//bool pm_mmap_recv(PMEM_MMAP_MTRLOGFILE_HDR* log_fil_hdr);
+bool pm_mmap_recv(uint64_t start_offset, uint64_t end_offset);
+uint64_t pm_mmap_recv_check(PMEM_MMAP_MTRLOGFILE_HDR* log_fil_hdr);
+void pm_mmap_recv_flush_buffer();
+
+// TODO(jhpark): covert these variables as structure (i.e., recv_sys_t)
+extern bool is_pmem_recv;
+extern uint64_t pmem_recv_offset;
+extern uint64_t pmem_recv_size;
+
+/** Recovery system data structure */
+//struct recv_sys_t{
+//  ib_mutex_t    mutex;
+	/*!< mutex protecting the fields apply_log_recs,
+	n_addrs, and the state field in each recv_addr struct */
+//  ib_mutex_t    writer_mutex; 
+	/*!< mutex coordinating 
+	flushing between recv_writer_thread and the recovery thread. */
+//  ibool   apply_log_recs;
+	/*!< this is TRUE when log rec application to pages is allowed; this flag tells the
+  i/o-handler if it should do log record application */
+//  byte*   buf;  /*!< buffer for parsing log records */
+//  ulint   len;  /*!< amount of data in buf */
+//};
+
 #endif  /* __PMEMMAPOBJ_H__ */

--- a/storage/innobase/include/ut0new.h
+++ b/storage/innobase/include/ut0new.h
@@ -654,10 +654,9 @@ public:
 		}
 
 		ulint	n_bytes = n_elements * sizeof(T);
-    size_t offset =  mmap_buf_sys->cur_offset;
+    size_t offset = mmap_buf_sys->cur_offset;
 		pointer	ptr = reinterpret_cast<pointer>(
       gb_pm_buf + offset
-		//	os_mem_alloc_large(&n_bytes)
     );
 
 #ifdef UNIV_PFS_MEMORY
@@ -669,8 +668,6 @@ public:
 #endif /* UNIV_PFS_MEMORY */
 
     mmap_buf_sys->cur_offset += n_bytes;
-		//fprintf(stderr, "[JONGQ] large_nvm allocation offset:%lu cur_offset:%lu\n", 
-		//								offset, mmap_buf_sys->cur_offset);
 
 		return(ptr);
 	}
@@ -689,7 +686,6 @@ public:
 		deallocate_trace(pfx);
 #endif /* UNIV_PFS_MEMORY */
 
-		// fprintf(stderr, "[JONGQ] deallocation free! ptr: %p size: %lu\n",ptr, pfx->m_size);
 		mmap_buf_sys->cur_offset -= pfx->m_size;
 		//os_mem_free_large(ptr, pfx->m_size);
 	}

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -1679,7 +1679,7 @@ recv_parse_or_apply_log_rec_body(
 	mtr_t*		mtr)
 {
 	ut_ad(!block == !mtr);
-
+	
 	switch (type) {
 	case MLOG_FILE_NAME:
 	case MLOG_FILE_DELETE:
@@ -2242,7 +2242,8 @@ recv_add_to_hash_table(
 		HASH_INSERT(recv_addr_t, addr_hash, recv_sys->addr_hash,
 			    recv_fold(space, page_no), recv_addr);
 		recv_sys->n_addrs++;
-#if 0
+		// debug
+#if 1
 		fprintf(stderr, "Inserting log rec for space %lu, page %lu\n",
 			space, page_no);
 #endif
@@ -2370,6 +2371,8 @@ recv_recover_page_func(
 		    recv_addr->space, recv_addr->page_no));
 #endif /* !UNIV_HOTBACKUP */
 
+  // debug
+  fprintf(stderr, "[JONGQ] state changed : !!! before: %d after: %d\n", recv_addr->state, RECV_BEING_PROCESSED);
 	recv_addr->state = RECV_BEING_PROCESSED;
 
 	mutex_exit(&(recv_sys->mutex));
@@ -2590,8 +2593,10 @@ recv_read_in_area(
 		const page_id_t	cur_page_id(page_id.space(), page_no);
 
 		if (recv_addr && !buf_page_peek(cur_page_id)) {
-
+			//debug
+			fprintf(stderr, "[JONGQ] recv-before-mutex i: %lu\n", page_no);
 			mutex_enter(&(recv_sys->mutex));
+			fprintf(stderr, "[JONGQ] recv-after-mutex i: %lu\n", page_no);  
 
 			if (recv_addr->state == RECV_NOT_PROCESSED) {
 				recv_addr->state = RECV_BEING_READ;
@@ -2604,8 +2609,10 @@ recv_read_in_area(
 			mutex_exit(&(recv_sys->mutex));
 		}
 	}
-
+	fprintf(stderr, "[JONGQ] call buf_read_recv_pages\n"); 
 	buf_read_recv_pages(FALSE, page_id.space(), page_nos, n);
+ 	fprintf(stderr, "[JONGQ] Recv pages at %lu n %lu\n", page_nos[0], n);
+
 	/*
 	fprintf(stderr, "Recv pages at %lu n %lu\n", page_nos[0], n);
 	*/
@@ -2694,6 +2701,10 @@ loop:
 					      stderr);
 					has_printed = TRUE;
 				}
+				
+				// debug
+				fprintf(stderr, "[JONGQ] i=%d recv_sys->n_addrs: %lu\n"
+											,i, recv_sys->n_addrs);
 
 				mutex_exit(&(recv_sys->mutex));
 
@@ -2712,6 +2723,7 @@ loop:
 					recv_recover_page(FALSE, block);
 					mtr_commit(&mtr);
 				} else {
+					fprintf(stderr, "[JONGQ] check-11!\n");
 					recv_read_in_area(page_id);
 				}
 
@@ -2729,6 +2741,8 @@ loop:
 				 / hash_get_n_cells(recv_sys->addr_hash)));
 		}
 	}
+	// debug
+	fprintf(stderr, "[JONGQ] escape for loop!\n");
 
 	/* Wait until all the pages have been processed */
 
@@ -2741,12 +2755,16 @@ loop:
 		mutex_enter(&(recv_sys->mutex));
 	}
 
+	fprintf(stderr, "[JONGQ] check-1!\n");
+
 	if (has_printed) {
 
 		fprintf(stderr, "\n");
 	}
 
 	if (!allow_ibuf) {
+
+		fprintf(stderr, "[JONGQ] check-3!\n"); 
 
 		/* Flush all the file pages to disk and invalidate them in
 		the buffer pool */
@@ -2787,6 +2805,8 @@ loop:
 	if (has_printed) {
 		ib::info() << "Apply batch completed";
 	}
+
+	fprintf(stderr, "[JONGQ] finish apply\n"); 
 
 	mutex_exit(&(recv_sys->mutex));
 }
@@ -3750,7 +3770,6 @@ recv_scan_log_recs(
 
 	if (more_data && !recv_sys->found_corrupt_log) {
 		/* Try to parse more log records */
-
 		if (recv_parse_log_recs(checkpoint_lsn,
 					*store_to_hash)) {
 			ut_ad(recv_sys->found_corrupt_log

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -6901,7 +6901,6 @@ AIO::reserve_slot(
 	local_seg = (offset >> (UNIV_PAGE_SIZE_SHIFT + 6)) % m_n_segments;
 
 	for (;;) {
-
 		acquire();
 
 		if (m_n_reserved != m_slots.size()) {
@@ -7446,21 +7445,16 @@ os_aio_func(
 	}
 
 try_again:
-
+  
 	AIO*	array;
-
 	array = AIO::select_slot_array(type, read_only, mode);
-
+	
 	Slot*	slot;
-
 	slot = array->reserve_slot(type, m1, m2, file, name, buf, offset, n);
 
 	if (type.is_read()) {
-
 		if (srv_use_native_aio) {
-
 			++os_n_file_reads;
-
 			os_bytes_read_since_printout += n;
 #ifdef WIN_ASYNC_IO
 			ret = ReadFile(
@@ -7476,7 +7470,6 @@ try_again:
 				AIO::get_segment_no_from_slot(array, slot));
 		}
 	} else if (type.is_write()) {
-
 		if (srv_use_native_aio) {
 			++os_n_file_writes;
 
@@ -7503,7 +7496,6 @@ try_again:
 		if ((ret && slot->len == slot->n_bytes)
 		     || (!ret && GetLastError() == ERROR_IO_PENDING)) {
 			/* aio was queued successfully! */
-
 			if (mode == OS_AIO_SYNC) {
 				IORequest	dummy_type;
 				void*		dummy_mess2;

--- a/storage/innobase/os/os0proc.cc
+++ b/storage/innobase/os/os0proc.cc
@@ -169,7 +169,6 @@ os_mem_free_large(
 	ulint	size)
 {
 	ut_a(os_total_large_mem_allocated >= size);
-
 #if defined HAVE_LINUX_LARGE_PAGES && defined UNIV_LINUX
 	if (os_use_large_pages && os_large_page_size && !shmdt(ptr)) {
 		os_atomic_decrement_ulint(

--- a/storage/innobase/page/page0cur.cc
+++ b/storage/innobase/page/page0cur.cc
@@ -1545,8 +1545,9 @@ use_heap:
           // skip generating REDO log for nvm-page
 					pm_mmap_mtrlogbuf_commit(insert_rec, rec_size, space_id, page_no);
         } else {
-        page_cur_insert_rec_write_log(insert_rec, rec_size,
-					        current_rec, index, mtr);
+          // original : 
+          page_cur_insert_rec_write_log(insert_rec, rec_size,
+          current_rec, index, mtr);
         }
 #else
         page_cur_insert_rec_write_log(insert_rec, rec_size,

--- a/storage/innobase/pmem/pmem0buf.cc
+++ b/storage/innobase/pmem/pmem0buf.cc
@@ -7,6 +7,7 @@
 // cur_offset starts after mtr_log region actual offset means (mtrlog retion size + cur_offset)
 
 extern PMEM_MMAP_MTRLOG_BUF* mmap_mtrlogbuf;
+extern bool is_pmem_recv;
 extern unsigned char* gb_pm_mmap;
 unsigned char* gb_pm_buf;
 
@@ -20,32 +21,28 @@ pm_mmap_buf_init(const uint64_t size) {
 	mmap_buf_sys->size = size;
 	mmap_buf_sys->n_pages = 0;
 	mmap_buf_sys->cur_offset = 0;
+
+  if (is_pmem_recv || mmap_mtrlogbuf==NULL) {
+    fprintf(stderr, "[recv] now we are on recover mode (is_pmem_recv: %d)\n", is_pmem_recv);
 	
-	gb_pm_buf = gb_pm_mmap + mmap_mtrlogbuf->size;
-	PMEMMMAP_INFO_PRINT("pm_mmap_buf initialization finished! size: %lu\n", mmap_mtrlogbuf->size);
+		// TODO(jhpark): support idempotent recovery!!
+    // 1024*1024*1024*1UL 
+    gb_pm_buf = gb_pm_mmap + (1024*1024*1024*1UL);
+    PMEMMMAP_INFO_PRINT("[recv] pm_mmap_buf initialization finished!\n");  
+  } else {	
+  	gb_pm_buf = gb_pm_mmap + mmap_mtrlogbuf->size;
+  	PMEMMMAP_INFO_PRINT("pm_mmap_buf initialization finished! size: %lu address: %p\n", size, gb_pm_buf);
+  }
 }
 
 void 
 pm_mmap_buf_free() {
 	if (mmap_buf_sys != NULL) {
-		ut_free(mmap_buf_sys);
+		pthread_mutex_destroy(&mmap_buf_sys->bufMutex);
+		free(mmap_buf_sys);
 		mmap_buf_sys = NULL;
 	}
-	pthread_mutex_destroy(&mmap_buf_sys->bufMutex);
 }
-
-/*
-unsigned char*
-pm_mmap_buf_chunk_alloc(unsigned long mem_size, ut_new_pfx_t* pfx) {
-	// (jhpark): allocation already finished @pm_mmap_buf_init.
-	// In this fucntion, we just pass the memory offset 
-	size_t offset = mmap_buf_sys->cur_offset;
-	mmap_buf_sys->cur_offset += mem_size;
-	fprintf(stderr, "[JONGQ] chunk_alloc !!! mem_size: %lu, offset: %lu\n", mem_size, offset);
-	pfx->m_size = mem_size;
-	return gb_pm_buf + offset;	
-}
-*/
 
 void
 pm_mmap_buf_write(unsigned long len, void* buf) {

--- a/storage/innobase/pmem/pmem0recv.cc
+++ b/storage/innobase/pmem/pmem0recv.cc
@@ -1,0 +1,213 @@
+#include "pmem_mmap_obj.h"
+
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stddef.h>
+
+#include "mtr0log.h"
+#include "buf0buf.h"
+#include "log0recv.h"
+#include "mtr0mtr.h"
+#include "fil0fil.h"
+
+#include "os0file.h"
+#include "page0page.h"
+#include "mtr0types.h"
+#include "trx0rec.h"
+
+extern unsigned char* gb_pm_mmap;
+extern uint64_t pmem_recv_size;
+
+uint64_t pm_mmap_recv_check(PMEM_MMAP_MTRLOGFILE_HDR* log_fil_hdr) {
+	size_t tmp_offset = log_fil_hdr->ckpt_offset;
+	while (true) {
+		fprintf(stderr, "current tmp_offset: %lu:(%lu)\n", tmp_offset, log_fil_hdr->size);
+		if (tmp_offset >= log_fil_hdr->size) {
+			break;
+		}
+
+		PMEM_MMAP_MTRLOG_HDR *recv_mmap_hdr = (PMEM_MMAP_MTRLOG_HDR *) malloc(PMEM_MMAP_MTRLOG_HDR_SIZE);
+		memcpy(recv_mmap_hdr, gb_pm_mmap + tmp_offset, PMEM_MMAP_MTRLOG_HDR_SIZE);
+		ut_ad(recv_mmap_hdr == NULL);
+
+		fprintf(stderr, "[recovery] need_recv: %d len: %lu lsn: %lu prev_offset: %lu space: %lu page_no: %lu\n"
+										,recv_mmap_hdr->need_recv, recv_mmap_hdr->len, recv_mmap_hdr->lsn,
+										recv_mmap_hdr->prev_offset,
+										recv_mmap_hdr->space, recv_mmap_hdr->page_no);
+
+    if (recv_mmap_hdr->need_recv == false) {
+      fprintf(stderr, "Hmm? current log doesn't need to recvoery!\n");
+      tmp_offset += recv_mmap_hdr->len;
+      free(recv_mmap_hdr);
+      continue;
+    } else {
+			free(recv_mmap_hdr);
+			return tmp_offset;
+		}
+	}
+	// no need to recovery
+  return -1;
+}
+
+bool pm_mmap_recv(uint64_t start_offset, uint64_t end_offset) {
+
+	mtr_t mtr;
+	size_t tmp_offset = start_offset;
+
+	while (true) {
+		fprintf(stderr, "current tmp_offset: %lu:(%lu)\n", tmp_offset, end_offset);
+
+		if (tmp_offset >= end_offset) {
+			break;
+		}
+
+		PMEM_MMAP_MTRLOG_HDR *recv_mmap_hdr = (PMEM_MMAP_MTRLOG_HDR *) malloc(PMEM_MMAP_MTRLOG_HDR_SIZE);
+		memcpy(recv_mmap_hdr, gb_pm_mmap + tmp_offset, PMEM_MMAP_MTRLOG_HDR_SIZE);
+		ut_ad(recv_mmap_hdr == NULL);
+
+		fprintf(stderr, "[recovery] need_recv: %d len: %lu lsn: %lu prev_offset: %lu space: %lu page_no: %lu\n"
+										,recv_mmap_hdr->need_recv, recv_mmap_hdr->len, recv_mmap_hdr->lsn,
+										recv_mmap_hdr->prev_offset,
+										recv_mmap_hdr->space, recv_mmap_hdr->page_no);
+
+    if (recv_mmap_hdr->need_recv == false) {
+      fprintf(stderr, "current log doesn't need to recvoery!\n");
+      tmp_offset += (PMEM_MMAP_MTRLOG_HDR_SIZE + recv_mmap_hdr->len);
+      free(recv_mmap_hdr);
+      continue;
+    }
+  
+		// page generation
+		bool found;
+		const page_size_t& page_size 
+			= fil_space_get_page_size(recv_mmap_hdr->space, &found);
+		
+		if (!found) {
+			fprintf(stderr, "This tablespace with that id (%lu) page (page_no: %lu) does not exist.\n"
+			,	recv_mmap_hdr->space, recv_mmap_hdr->page_no);
+		}	
+
+		const page_id_t   page_id(recv_mmap_hdr->space, recv_mmap_hdr->page_no);
+		if (buf_page_peek(page_id)) {
+			buf_block_t*  block;
+			mtr_start(&mtr);
+			block = buf_page_get( page_id, page_size, RW_X_LATCH, &mtr);
+			recv_recover_page(FALSE, block);
+			fprintf(stderr, " page (page_no: %lu) is recovered!\n", recv_mmap_hdr->page_no);
+			mtr_commit(&mtr); 	
+		} else {
+			// TODO(jhpark): implement nc version `recv_read_in_area()`
+			fprintf(stderr, "current page doesn't exist buffer!\n");
+			//ulint page_nos[1]; 
+			//page_nos[0] = recv_mmap_hdr->page_no; // just one element
+			//buf_read_recv_pages(TRUE, page_id.space(), page_nos, 1);
+			//fprintf(stderr, "Recv pages at %lu\n", page_nos[0]); 
+		  //recv_read_in_area(page_id);
+
+      // Force recovery UNDO page 
+      byte *mlog_data =  (byte*) malloc(recv_mmap_hdr->len);
+      memcpy(mlog_data, gb_pm_mmap + tmp_offset + PMEM_MMAP_MTRLOG_HDR_SIZE, sizeof(*mlog_data)); 
+      byte* ptr = mlog_data;
+      byte* end_ptr = mlog_data + recv_mmap_hdr->len;
+      mlog_id_t type;
+      type = (mlog_id_t)((ulint)*ptr & ~MLOG_SINGLE_REC_FLAG);
+    
+      // get current page with space_id and page_no
+
+			mtr_start(&mtr); 
+			buf_block_t* block = buf_page_get( page_id, page_size, RW_X_LATCH, &mtr);
+      byte* page = block->frame;
+			if (page == NULL) {
+				fprintf(stderr,"[JOGNQ] Tried to undo page but it is NULL!\n");
+			} else {
+				fprintf(stderr,"[JONGQ] YES!!! UNDO is right!!!\n");
+			}
+     	mtr_commit(&mtr); 
+
+      switch(type) {
+        case MLOG_UNDO_INSERT:
+          ptr = trx_undo_parse_add_undo_rec(ptr, end_ptr, page);
+					fprintf(stderr, "[JONGQ] success!\n");
+					IORequest write_request(IORequest::WRITE);
+					write_request.disable_compression(); // stil needed?
+					fprintf(stderr, "[JONGQ] perform fil_io write!!!\n");
+					int check = 0;
+					check = fil_io(write_request, true, page_id, 
+					univ_page_size, 0, univ_page_size.physical(), (void*) page, NULL);
+					fprintf(stderr, "[JONGQ] fio_io result: %d\n", check);
+      };
+      // free mlog data
+      free(mlog_data);
+
+		}
+
+    tmp_offset += (PMEM_MMAP_MTRLOG_HDR_SIZE + recv_mmap_hdr->len);
+    free(recv_mmap_hdr);
+	}
+
+  return true;
+}
+
+
+void pm_mmap_recv_flush_buffer() {
+	// step1. grap information of all nc buffer pages (space, page_no)
+	// TODO(jhpark): need to modify to get pmem_log_buffer size automatically
+
+	uint64_t cur_offset = 0;
+	uint64_t total_buf_size = (1024*1024*1024*2UL);
+	unsigned char* cur_gb_pm_buf = gb_pm_mmap + (1024*1024*3UL);
+
+	while (true) {
+		if (cur_offset >= total_buf_size) {
+			break;
+		}
+
+		// In this phase, buffer pool is already allocated,
+		// copy these frame to allocated frame of buf_block_t
+		// buffer_pool_t -> buf_chunk_t -> buf_block_t -> frame
+		// or---!!! just copy as bug_page_t (with UNIV_PAGE_SIZE)
+		
+		// TODO(jhpark): convert page size as constant variable
+		byte* buf = (byte*) malloc(4096*1024); // 4KB page
+		memcpy(buf, gb_pm_mmap + cur_offset, (4096*1024));
+		// align page
+		page_align(buf);
+
+		// check page information
+		// refer to btr0btr.ic
+		// first check page_no and space_id
+		
+		unsigned long space_id = mach_read_from_4(buf + FIL_PAGE_SPACE_ID);
+		unsigned long page_no = mach_read_from_4(buf + FIL_PAGE_OFFSET);  			
+		
+		fprintf(stderr, "[JONGQ] cur_offset: %lu, space_id: %lu, page_no: %lu\n"
+		,cur_offset, space_id, page_no);		
+
+		if (space_id == 28 || space_id == 30) {
+			//&& page_no == 0)) {
+			// perform fil_io
+			IORequest write_request(IORequest::WRITE);
+			write_request.disable_compression(); // stil needed?
+
+			// similar process, partila updates! 
+			write_request.dblwr_recover();
+			fprintf(stderr, "[JONGQ] perform fil_io write!!!\n");
+			int check = 0;
+			check = fil_io(write_request, true, page_id_t(space_id, page_no), 
+					univ_page_size, 0 ,univ_page_size.physical(), (void*) buf, NULL);
+
+			fprintf(stderr, "[JONGQ] fil_io check: %d!\n", check);
+		}
+
+		cur_offset += (4096*1024);
+		free(buf);
+	}
+
+    // step2. call fil_io() function to flush current 
+    // note that changes on these pages are not atomic 
+    // they might have partial updates
+}

--- a/storage/innobase/row/row0uins.cc
+++ b/storage/innobase/row/row0uins.cc
@@ -128,7 +128,17 @@ row_undo_ins_remove_clust_rec(
 		dict_drop_index_tree(
 			btr_pcur_get_rec(&node->pcur), &(node->pcur), &mtr);
 
+#ifdef UNIV_NVDIMM_CACHE
+		if (index->space == 28) {
+			mtr_commit_no_nvm(&mtr);
+		} else {
+			mtr_commit(&mtr);
+		}
+#else
 		mtr_commit(&mtr);
+#endif
+
+//		mtr_commit(&mtr);
 
 		mtr_start(&mtr);
 
@@ -142,7 +152,22 @@ row_undo_ins_remove_clust_rec(
 		goto func_exit;
 	}
 
+#ifdef UNIV_NVDIMM_CACHE
+	if (index->space == 28) {
+ 		//btr_pcur_commit_specify_mtr(&node->pcur, &mtr);
+    ut_ad(node->pcur.pos_state == BTR_PCUR_IS_POSITIONED);
+    node->pcur.latch_mode = BTR_NO_LATCHES;
+    mtr_commit_no_nvm(&mtr);
+    node->pcur.pos_state = BTR_PCUR_WAS_POSITIONED;     
+  } else {
+		btr_pcur_commit_specify_mtr(&node->pcur, &mtr);
+	}
+#else
 	btr_pcur_commit_specify_mtr(&node->pcur, &mtr);
+#endif
+
+//	btr_pcur_commit_specify_mtr(&node->pcur, &mtr);
+
 retry:
 	/* If did not succeed, try pessimistic descent to tree */
 	mtr_start(&mtr);
@@ -163,7 +188,20 @@ retry:
 	if (err == DB_OUT_OF_FILE_SPACE
 	    && n_tries < BTR_CUR_RETRY_DELETE_N_TIMES) {
 
+//		btr_pcur_commit_specify_mtr(&(node->pcur), &mtr);
+#ifdef UNIV_NVDIMM_CACHE
+	if (index->space == 28) {
+  	//btr_pcur_commit_specify_mtr(&node->pcur, &mtr);
+    ut_ad(node->pcur.pos_state == BTR_PCUR_IS_POSITIONED);
+    node->pcur.latch_mode = BTR_NO_LATCHES;
+    mtr_commit_no_nvm(&mtr);
+    node->pcur.pos_state = BTR_PCUR_WAS_POSITIONED;
+	} else {
 		btr_pcur_commit_specify_mtr(&(node->pcur), &mtr);
+	}
+#else
+	btr_pcur_commit_specify_mtr(&(node->pcur), &mtr);
+#endif
 
 		n_tries++;
 
@@ -173,7 +211,21 @@ retry:
 	}
 
 func_exit:
+//	btr_pcur_commit_specify_mtr(&node->pcur, &mtr);
+
+#ifdef UNIV_NVDIMM_CACHE
+	if (index->space == 28) {
+	 	//btr_pcur_commit_specify_mtr(&node->pcur, &mtr);
+    ut_ad(node->pcur.pos_state == BTR_PCUR_IS_POSITIONED);
+    node->pcur.latch_mode = BTR_NO_LATCHES;
+    mtr_commit_no_nvm(&mtr);
+    node->pcur.pos_state = BTR_PCUR_WAS_POSITIONED;
+  } else {
+		btr_pcur_commit_specify_mtr(&node->pcur, &mtr);
+	}
+#else
 	btr_pcur_commit_specify_mtr(&node->pcur, &mtr);
+#endif
 
 	return(err);
 }

--- a/storage/innobase/row/row0umod.cc
+++ b/storage/innobase/row/row0umod.cc
@@ -267,10 +267,11 @@ row_undo_mod_clust(
 	ut_ad(rw_lock_own(dict_operation_lock, RW_LOCK_S)
 	      || rw_lock_own(dict_operation_lock, RW_LOCK_X));
 
+
 	log_free_check();
 	pcur = &node->pcur;
 	index = btr_cur_get_index(btr_pcur_get_btr_cur(pcur));
-
+	
 	mtr_start(&mtr);
 	mtr.set_named_space(index->space);
 	dict_disable_redo_if_temporary(index->table, &mtr);

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -2493,6 +2493,11 @@ row_upd_clust_rec_by_insert(
 
 	heap = mem_heap_create(1000);
 
+	// debug
+	if (index->space == 28) {
+		fprintf(stderr,"[JONGQ] row_upd_clust_rec_by_insert() check!\n");
+	}
+
 	entry = row_build_index_entry_low(node->upd_row, node->upd_ext,
 					  index, heap, ROW_BUILD_FOR_INSERT);
 	ut_ad(dtuple_get_info_bits(entry) == 0);

--- a/storage/innobase/trx/trx0rseg.cc
+++ b/storage/innobase/trx/trx0rseg.cc
@@ -242,6 +242,9 @@ trx_rseg_mem_create(
 		rseg->last_page_no = node_addr.page;
 		rseg->last_offset = node_addr.boffset;
 
+    //debug
+    //fprintf(stderr, "[JONGQ] trx_rseg_mem_create space: %lu page_no: %lu\n", rseg->space, node_addr.page);
+
 		undo_log_hdr = trx_undo_page_get(
 			page_id_t(rseg->space, node_addr.page),
 			rseg->page_size, mtr) + node_addr.boffset;
@@ -336,7 +339,7 @@ trx_rseg_create_instance(
 		Non-redo rsegs are recreated on server re-start so
 		avoid initializing the existing non-redo rsegs. */
 		if (trx_sys_is_noredo_rseg_slot(i)) {
-
+			
 			/* If this is an upgrade scenario then existing rsegs
 			in range from slot-1....slot-n needs to be scheduled
 			for purge if there are pending purge operation. */
@@ -349,7 +352,9 @@ trx_rseg_create_instance(
 
 			ut_a(!trx_rseg_get_on_id(i, true));
 
+      //fprintf(stderr, "[JONGQ] page_no != FIL_NULL page_no: %lu \n", page_no);
 			space = trx_sysf_rseg_get_space(sys_header, i, &mtr);
+      //fprintf(stderr, "[JONGQ] space : %lu\n", space);
 
 			bool			found = true;
 			const page_size_t&	page_size

--- a/storage/innobase/trx/trx0sys.cc
+++ b/storage/innobase/trx/trx0sys.cc
@@ -484,19 +484,21 @@ trx_sys_init_at_db_start(void)
 		+ ut_uint64_align_up(mach_read_from_8(sys_header
 						   + TRX_SYS_TRX_ID_STORE),
 				     TRX_SYS_TRX_ID_WRITE_MARGIN);
-
 	mtr.commit();
 	ut_d(trx_sys->rw_max_trx_id = trx_sys->max_trx_id);
-
 	trx_dummy_sess = sess_open();
-
+  PMEMMMAP_INFO_PRINT("JONGQ recovery-trx_sys_init-22\n");      
 	trx_lists_init_at_db_start();
 
 	/* This mutex is not strictly required, it is here only to satisfy
 	the debug code (assertions). We are still running in single threaded
 	bootstrap mode. */
 
+  PMEMMMAP_INFO_PRINT("JONGQ recovery-trx_sys_init-3\n");
+
 	trx_sys_mutex_enter();
+
+  PMEMMMAP_INFO_PRINT("JONGQ recovery-trx_sys_init-4\n");
 
 	if (UT_LIST_GET_LEN(trx_sys->rw_trx_list) > 0) {
 		const trx_t*	trx;

--- a/storage/innobase/trx/trx0undo.cc
+++ b/storage/innobase/trx/trx0undo.cc
@@ -216,13 +216,11 @@ trx_undo_get_prev_rec(
 	prev_rec = trx_undo_page_get_prev_rec(rec, page_no, offset);
 
 	if (prev_rec) {
-
 		return(prev_rec);
 	}
 
 	/* We have to go to the previous undo log page to look for the
 	previous record */
-
 	return(trx_undo_get_prev_rec_from_prev_page(rec, page_no, offset,
 						    shared, mtr));
 }


### PR DESCRIPTION
- disable all REDO logging for new order tablespace
- fix normal shutdown bugs
- ignoring  buf corruption warning for NC pages